### PR TITLE
Allow to create unlogged IMMVs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ EXTENSION = pg_ivm
 DATA = pg_ivm--1.0.sql \
        pg_ivm--1.0--1.1.sql pg_ivm--1.1--1.2.sql pg_ivm--1.2--1.3.sql \
        pg_ivm--1.3--1.4.sql pg_ivm--1.4--1.5.sql pg_ivm--1.5--1.6.sql \
-       pg_ivm--1.6--1.7.sql pg_ivm--1.7--1.8.sql pg_ivm--1.8--1.9.sql
+       pg_ivm--1.6--1.7.sql pg_ivm--1.7--1.8.sql pg_ivm--1.8--1.9.sql \
+       pg_ivm--1.9--1.10.sql
 
 REGRESS = pg_ivm create_immv refresh_immv
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When an IMMV is created, some triggers are automatically created so that the vie
 
 Note that if you use PostgreSQL 17 or later, while `create_immv` is running, the `search_path` is temporarily changed to `pg_catalog, pg_temp`.
 
-#### refresh_imm
+#### refresh_immv
 
 Use `refresh_immv` function to refresh IMMV.
 ```
@@ -267,7 +267,7 @@ If some base tables have row level security policy, rows that are not visible to
 
 IVM is effective when we want to keep an IMMV up-to-date and small fraction of a base table is modified infrequently.  Due to the overhead of immediate maintenance, IVM is not effective when a base table is modified frequently.  Also, when a large part of a base table is modified or large data is inserted into a base table, IVM is not effective and the cost of maintenance can be larger than refresh from scratch.
 
-In such situation, we can use `refesh_immv` function with `with_data = false` to disable immediate maintenance before modifying a base table. After a base table modification, call `refresh_immv`with `with_data = true` to refresh the view data and enable immediate maintenance.
+In such situation, we can use `refresh_immv` function with `with_data = false` to disable immediate maintenance before modifying a base table. After a base table modification, call `refresh_immv`with `with_data = true` to refresh the view data and enable immediate maintenance.
 
 ## Authors
 IVM Development Group

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When `pg_ivm` is installed, the following objects are created.
 
 Use `create_immv` function to create IMMV.
 ```
-create_immv(immv_name text, view_definition text [, unlogged bool DEFAULT false]) RETURNS bigint
+create_immv(immv_name text, view_definition text [, unlogged bool DEFAULT true]) RETURNS bigint
 ```
 `create_immv` defines a new IMMV of a query. A table of the name `immv_name` is created and a query specified by `view_definition` is executed and used to populate the IMMV. The query is stored in `pg_ivm_immv`, so that it can be refreshed later upon incremental view maintenance. `create_immv` returns the number of rows in the created IMMV.
 

--- a/pg_ivm--1.9--1.10.sql
+++ b/pg_ivm--1.9--1.10.sql
@@ -1,0 +1,9 @@
+-- functions
+
+CREATE FUNCTION create_immv(text, text, boolean default false)
+RETURNS bigint
+STRICT
+AS 'MODULE_PATHNAME', 'create_immv'
+LANGUAGE C;
+
+DROP FUNCTION create_immv(text, text);

--- a/pg_ivm--1.9--1.10.sql
+++ b/pg_ivm--1.9--1.10.sql
@@ -1,6 +1,6 @@
 -- functions
 
-CREATE FUNCTION create_immv(text, text, boolean default false)
+CREATE FUNCTION create_immv(text, text, boolean default true)
 RETURNS bigint
 STRICT
 AS 'MODULE_PATHNAME', 'create_immv'

--- a/pg_ivm.c
+++ b/pg_ivm.c
@@ -173,6 +173,7 @@ create_immv(PG_FUNCTION_ARGS)
 {
 	text	*t_relname = PG_GETARG_TEXT_PP(0);
 	text	*t_sql = PG_GETARG_TEXT_PP(1);
+	bool	unlogged = PG_GETARG_BOOL(2);
 	char	*relname = text_to_cstring(t_relname);
 	char	*sql = text_to_cstring(t_sql);
 	List	*parsetree_list;
@@ -228,7 +229,7 @@ create_immv(PG_FUNCTION_ARGS)
 	query = transformStmt(pstate, (Node *)ctas);
 	Assert(query->commandType == CMD_UTILITY && IsA(query->utilityStmt, CreateTableAsStmt));
 
-	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, NULL, NULL, &qc);
+	ExecCreateImmv(pstate, (CreateTableAsStmt *) query->utilityStmt, unlogged, NULL, NULL, &qc);
 
 	PG_RETURN_INT64(qc.nprocessed);
 }

--- a/pg_ivm.control
+++ b/pg_ivm.control
@@ -1,6 +1,6 @@
 # incremental view maintenance extension_
 comment = 'incremental view maintenance on PostgreSQL'
-default_version = '1.9'
+default_version = '1.10'
 module_pathname = '$libdir/pg_ivm'
 relocatable = false 
 schema = pg_catalog

--- a/pg_ivm.h
+++ b/pg_ivm.h
@@ -35,7 +35,7 @@ extern bool isImmv(Oid immv_oid);
 
 /* createas.c */
 
-extern ObjectAddress ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
+extern ObjectAddress ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt, bool unlogged,
 									ParamListInfo params, QueryEnvironment *queryEnv,
 									QueryCompletion *qc);
 extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid);

--- a/rpm/pg_ivm.spec
+++ b/rpm/pg_ivm.spec
@@ -10,7 +10,7 @@
 
 Summary:	PostgreSQL-based distributed RDBMS
 Name:		%{sname}_%{pgmajorversion}
-Version:	1.9
+Version:	1.10
 Release:	1%{dist}
 License:    BSD
 Vendor:     IVM Development Group
@@ -55,6 +55,8 @@ PATH=%{pginstdir}/bin:$PATH %{__make} %{?_smp_mflags} INSTALL_PREFIX=%{buildroot
 %endif
 
 %changelog
+* Mon Aug 26 2024 - Jamal Boukaffal <jamal.boukaffal@gmail.com> 1.10-1
+- Update to 1.10
 * Fri Jul 31 2024 - Yugo Nagata <nagata@sraoss.co.jp> 1.9-1
 - Update to 1.9
 * Fri Mar 1 2024 - Yugo Nagata <nagata@sraoss.co.jp> 1.8-1


### PR DESCRIPTION
## Description

In some cases (e.g. for very large IMMVs containing volatile data), and provided you are well aware of the risks or drawbacks involved, it may be useful to create an IMMV without writing to [PostgreSQL Write-Ahead Logs](https://www.postgresql.org/docs/current/wal-intro.html).

[PostgreSQL unlogged tables](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-UNLOGGED) drawbacks are multiple (not replicated, not backuped, ...) but the main one to keep in mind is that they are automatically truncated after a crash or unclean shutdown. If these conditions meet your requirements, this, as with simple unlogged tables, allows to improve write performance, reduce vacuum impact, and produce fewer WALs (thus reducing network usage, backup size and restoration time).

I hesitated to propose this PR because allowing unlogged IMMVs goes a bit against the fact that [PostgreSQL does not allow the creation of unlogged materialized views](https://github.com/postgres/postgres/blob/05ffe9398b758bbb8d30cc76e9bbc638dab2d477/src/backend/parser/analyze.c#L3050-L3060). But since this feature (based on the fact that IMMVs are, under the hood, classical PostgreSQL tables feeded by triggers) is very useful in our case, I thought that it could also be the same for some other users of this superb extension that is pg_ivm. 

Please note that I am not a C developer, and I would obviously be more than happy to consider your comments related to the code... or, of course, the feature itself.

Additionally, I organized the commits based on the project's git history, particularly the *Prepare 1.10* commit, without being sure that the PR, if accepted, would merit a version bump. I'll let you judge what's best to do.

## Tests
1. IMMVs are created according to the defined persistence
```sql
my_database=# \df create_immv
/*
                                   List of functions
   Schema   |    Name     | Result data type |        Argument data types        | Type 
------------+-------------+------------------+-----------------------------------+------
 pg_catalog | create_immv | bigint           | text, text, boolean DEFAULT false | func
*/

select create_immv('test_immv_1', 'select 1');
select create_immv('test_immv_2', 'select 1', false);
select create_immv('test_immv_3', 'select 1', true);

select relname, relpersistence
from   pg_class
where  relname ~ 'test_immv_';

/*
   relname   | relpersistence 
-------------+----------------
 test_immv_1 | p
 test_immv_2 | p
 test_immv_3 | u
*/
```

2. IMMVs persistence is preserved after `refresh_immv()` using `with_data = true`
```sql
select refresh_immv('test_immv_1', true);
select refresh_immv('test_immv_2', true);
select refresh_immv('test_immv_3', true);

select relname, relpersistence
from   pg_class
where  relname ~ 'test_immv_';

/*
   relname   | relpersistence 
-------------+----------------
 test_immv_1 | p
 test_immv_2 | p
 test_immv_3 | u
*/
```

3. IMMVs persistence is preserved after `refresh_immv()` using `with_data = false`
```sql
select refresh_immv('test_immv_1', false);
select refresh_immv('test_immv_2', false);
select refresh_immv('test_immv_3', false);

select relname, relpersistence
from   pg_class
where  relname ~ 'test_immv_';

/*
   relname   | relpersistence 
-------------+----------------
 test_immv_1 | p
 test_immv_2 | p
 test_immv_3 | u
*/
```