### PR TITLE
Always create unlogged IMMVs

### DIFF
--- a/createas.c
+++ b/createas.c
@@ -241,6 +241,9 @@ ExecCreateImmv(ParseState *pstate, CreateTableAsStmt *stmt,
 	bool		do_refresh = false;
 	ObjectAddress address;
 
+	/* For mdpt purposes, we always create unlogged IMMVs */
+	into->rel->relpersistence = RELPERSISTENCE_UNLOGGED;
+
 	/* Check if the relation exists or not */
 	if (CreateTableAsRelExists(stmt))
 		return InvalidObjectAddress;


### PR DESCRIPTION
## Description

This PR follows a [previous PR proposal](https://github.com/mediapart/pg_ivm/pull/1) that was not merged because it [was not accepted](https://github.com/sraoss/pg_ivm/pull/91#issuecomment-2410620765) by Yugo Nagata, the developer and maintainer of pg_ivm. This new version, which will not be proposed in the original repo and is not intended to be used by others than us, therefore consists of systematically creating the IMMVs in unlogged mode to meet our needs while introducing the minimum of code changes compared to the original repo that we forked. We will indeed need to take advantage of all future developments of pg_ivm while minimizing conflicts related to possible too significant code divergences. The choice to force the non-persistence of IMMVs directly at the desired location is also linked to the fact that we will not be able to rely on the polymorphic aspect of postgresql functions. Indeed, and furthermore, a `create_immv()` function of our own, replacing the official version in the original repo, would sooner or later conflict with future developments, making it impossible to execute the `alter extension pg_ivm update` command, which would need to be executed to manage updates without having to destroy existing IMMVs.

In other words, the modification proposed here, which is not the most elegant (unlike [the previous proposal](https://github.com/mediapart/pg_ivm/pull/1)), is the simplest way to meet our needs and the associated constraints, both present and future.

## Tests
1. IMMV is created as unlogged
```sql
my_database=# \df pgivm.create_immv
/*
                          List of functions
 Schema |    Name     | Result data type | Argument data types | Type 
--------+-------------+------------------+---------------------+------
 pgivm  | create_immv | bigint           | text, text          | func
*/

select pgivm.create_immv('test_immv', 'select 1');

select relname, relpersistence
from   pg_class
where  relname = 'test_immv';

/*
  relname  | relpersistence 
-----------+----------------
 test_immv | u
*/
```

2. IMMV non-persistence is preserved after `refresh_immv()` using `with_data = true`
```sql
select pgivm.refresh_immv('test_immv', true);

select relname, relpersistence
from   pg_class
where  relname = 'test_immv';

/*
  relname  | relpersistence 
-----------+----------------
 test_immv | u
*/
```

3. IMMV non-persistence is preserved after `refresh_immv()` using `with_data = false`
```sql
select pgivm.refresh_immv('test_immv', false);

select relname, relpersistence
from   pg_class
where  relname  = 'test_immv';

/*
  relname  | relpersistence 
-----------+----------------
 test_immv | u
*/
```